### PR TITLE
TOP-23320 - add acl support

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -62,6 +62,7 @@ type S3Bucket struct {
 	Name                           string
 	AWSConfig                      *aws.Config
 	Bucket                         string
+	Acl                            string
 	KeyPrefix                      Path
 	MaxObjectSize                  int64
 	Users                          UserStore
@@ -142,6 +143,7 @@ func buildS3Bucket(uStores UserStores, name string, bCfg *S3BucketConfig) (*S3Bu
 		KeyPrefix:     keyPrefix,
 		MaxObjectSize: maxObjectSize,
 		Users:         users,
+		Acl:           bCfg.Acl,
 		Perms: Perms{
 			Readable: *bCfg.Readable,
 			Writable: *bCfg.Writable,

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ type AWSCredentialsConfig struct {
 
 type S3BucketConfig struct {
 	Profile                        string                   `toml:"profile"`
+	Acl                            string                   `toml:"acl"`
 	Credentials                    *AWSCredentialsConfig    `toml:"credentials"`
 	Region                         string                   `toml:"region"`
 	Bucket                         string                   `toml:"bucket"`
@@ -107,6 +108,9 @@ func validateAndFixupBucketConfig(bCfg *S3BucketConfig) error {
 	}
 	if bCfg.Listable == nil {
 		bCfg.Listable = &vTrue
+	}
+	if bCfg.Acl == "" {
+		bCfg.Acl = "private"
 	}
 	return nil
 }


### PR DESCRIPTION
Needed for cross-account usage. Move from hard-coded "private" to a configurable setting, so that we can use "bucket-owner-full-control".